### PR TITLE
File APIで指定した楽曲の表示

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     ruby_dep (1.5.0)
     ruby_parser (3.13.1)
       sexp_processor (~> 4.9)
-    rubyzip (1.2.4)
+    rubyzip (1.3.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -63,8 +63,9 @@ body {
   &__name_artists {
     float: left;
     height: 60px;
-    width: 650px;
+    width: 640px;
     margin-top: 25px;
+    padding-left: 10px;
     line-height: 60px;
     background-color: #FFFFFF;
   }
@@ -126,12 +127,15 @@ body {
     white-space: nowrap;
     background-color: darkgray;
     color: #FFFFFF;
+    &:hover {
+      cursor: default;
+    }
     & thead {
       & tr th#head-ID {
         min-width: calc((100vw - 350px) * 0.03);
       }
       & tr th#head-titles {
-        min-width: calc((100vw - 350px) * 0.3);
+        min-width: calc((100vw - 350px) * 0.25);
       }
       & tr th#head-artists {
         min-width: calc((100vw - 350px) * 0.15);
@@ -140,7 +144,7 @@ body {
         min-width: calc((100vw - 350px) * 0.15);
       }
       & tr th#head-album-artists {
-        min-width: calc((100vw - 350px) * 0.3);
+        min-width: calc((100vw - 350px) * 0.25);
       }
       & tr th#head-length {
         min-width: calc((100vw - 350px) * 0.1);
@@ -156,6 +160,9 @@ body {
       padding: 10px 0px;
     }
     & tbody {
+      &:hover {
+        cursor: pointer;
+      }
       & tr td {
         border-color: #FFFFFF;
         border: solid 2px #FFFFFF;

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -126,34 +126,37 @@ body {
     white-space: nowrap;
     background-color: darkgray;
     color: #FFFFFF;
-    & tbody {
-      & th#title {
+    & thead {
+      & tr th#head-titles {
         min-width: calc((100vw - 350px) * 0.3);
       }
-      & th#artists {
+      & tr th#head-artists {
         min-width: calc((100vw - 350px) * 0.15);
       }
-      & th#album-artists {
+      & tr th#head-album-artists {
         min-width: calc((100vw - 350px) * 0.3);
       }
-      & th#length {
+      & tr th#head-length {
         min-width: calc((100vw - 350px) * 0.1);
       }
-      & th#genre {
-        min-width: calc((100vw - 350px) * 0.12);
+      & tr th#head-genres {
+        min-width: calc((100vw - 350px) * 0.1425);
+        // min-width: calc((100vw - 350px) * 0.119475);
       }
     }
-    & thead tr th {
+    & tr th {
       border-color: #FFFFFF;
       border: solid 2px #FFFFFF;
       text-align: center;
       padding: 10px 0px;
     }
-    & tbody tr th {
-      border-color: #FFFFFF;
-      border: solid 2px #FFFFFF;
-      text-align: left;
-      padding: 10px 0px 10px 10px;
+    & tbody {
+      & tr td {
+        border-color: #FFFFFF;
+        border: solid 2px #FFFFFF;
+        text-align: left;
+        padding: 10px 0px 10px 10px;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -133,6 +133,9 @@ body {
       & tr th#head-artists {
         min-width: calc((100vw - 350px) * 0.15);
       }
+      & tr th#head-album {
+        min-width: calc((100vw - 350px) * 0.15);
+      }
       & tr th#head-album-artists {
         min-width: calc((100vw - 350px) * 0.3);
       }

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -127,6 +127,9 @@ body {
     background-color: darkgray;
     color: #FFFFFF;
     & thead {
+      & tr th#head-ID {
+        min-width: calc((100vw - 350px) * 0.03);
+      }
       & tr th#head-titles {
         min-width: calc((100vw - 350px) * 0.3);
       }

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -115,30 +115,46 @@ body {
 
 .music-lists {
   position: absolute;
-  height: calc(100vh - 250px);
-  width: calc(100vw - 350px);
-  margin-left: 350px;
-  margin-top: 250px;
+  top: 250px;
+  left: 350px;
   background-color: #FFFFFF;
+  table#music-lists-table {
+    height: calc(100vh - 250px);
+    width: calc(100vw - 350px);
+    display: block;
+    overflow-x: scroll;
+    white-space: nowrap;
+    background-color: darkgray;
+    color: #FFFFFF;
+    & tbody {
+      & th#title {
+        min-width: calc((100vw - 350px) * 0.3);
+      }
+      & th#artists {
+        min-width: calc((100vw - 350px) * 0.15);
+      }
+      & th#album-artists {
+        min-width: calc((100vw - 350px) * 0.3);
+      }
+      & th#length {
+        min-width: calc((100vw - 350px) * 0.1);
+      }
+      & th#genre {
+        min-width: calc((100vw - 350px) * 0.12);
+      }
+    }
+    & thead tr th {
+      border-color: #FFFFFF;
+      border: solid 2px #FFFFFF;
+      text-align: center;
+      padding: 10px 0px;
+    }
+    & tbody tr th {
+      border-color: #FFFFFF;
+      border: solid 2px #FFFFFF;
+      text-align: left;
+      padding: 10px 0px 10px 10px;
+    }
+  }
 }
 
-table#music-lists-table {
-  height: calc(100vh - 250px);
-  width: calc(100vw - 350px);
-  background-color: darkgray;
-  color: #FFFFFF;
-  overflow: scroll;
-  // border-bottom-width: 10px;
-  & thead tr th {
-    border-color: #FFFFFF;
-    border: solid 2px #FFFFFF;
-    text-align: center;
-    padding: 10px 0px;
-  }
-  & tbody tr th {
-    border-color: #FFFFFF;
-    border: solid 2px #FFFFFF;
-    text-align: left;
-    padding: 10px 0px 10px 10px; 
-  }
-}

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -5,13 +5,11 @@ body {
 }
 
 .side-bar {
-  // position: absolute;
   float: left;
   height: 100vh;
   width: 350px;
   background-color: #06A230;
   &__user-box {
-    // position: relative;
     height: 200px;
     width: 300px;
     margin: 25px;
@@ -129,11 +127,13 @@ table#music-lists-table {
   width: calc(100vw - 350px);
   background-color: darkgray;
   color: #FFFFFF;
+  overflow: scroll;
   // border-bottom-width: 10px;
   & thead tr th {
     border-color: #FFFFFF;
     border: solid 2px #FFFFFF;
-    padding: 10px 50px 10px 10px;
+    text-align: center;
+    padding: 10px 0px;
   }
   & tbody tr th {
     border-color: #FFFFFF;

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -155,7 +155,7 @@ body {
         border-color: #FFFFFF;
         border: solid 2px #FFFFFF;
         text-align: left;
-        padding: 10px 0px 10px 10px;
+        padding: 10px 10px 10px 10px;
       }
     }
   }

--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -141,7 +141,6 @@ body {
       }
       & tr th#head-genres {
         min-width: calc((100vw - 350px) * 0.1425);
-        // min-width: calc((100vw - 350px) * 0.119475);
       }
     }
     & tr th {
@@ -161,3 +160,6 @@ body {
   }
 }
 
+.active {
+  background-color: rgb(154, 240, 187);
+}

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -325,7 +325,7 @@ let input = function() {
   let fileReader = [];
   for(let j = 0; j < document.getElementById("file-upload-audio").files.length; j++) {
     fileReader[j] = "fileReader" + String(j);
-  };
+  }
   document.getElementById('music-lists-tunes').textContent = null;
   
   for(let k = 0; k < document.getElementById("file-upload-audio").files.length; k++) {
@@ -361,7 +361,7 @@ let input = function() {
         document.getElementById('length' + String(k+1)).innerHTML = parseTime(buffer.duration);
       });
     };
-  };
+  }
 
   // リストのダブルクリックで音楽の再生（最初のページ読み込み時にtune-recordが存在しないため、ここで作成）
   let tuneRecord = document.getElementsByClassName("tune-record");
@@ -371,7 +371,7 @@ let input = function() {
       listNum = this.id - 1;
       play(this.id-1);
     }, false);
-  };
+  }
 
 };
 

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -346,7 +346,8 @@ let input = function() {
 
     let musicTable = document.getElementById('music-lists-tunes');
     let row = musicTable.insertRow(-1);
-    row.id = 'record' + String(k+1);
+    row.id = k+1;
+    document.getElementById(k+1).classList.add("tune-record");
     let titleCell = row.insertCell(-1);
     titleCell.id = 'title' + String(k+1);
     let artistsCell = row.insertCell(-1);
@@ -366,12 +367,28 @@ let input = function() {
       data = new Uint8Array(value);
       get_metadata(data, k);
     };
-  }
+  };
+
+  // リストのダブルクリックで音楽の再生
+  let tuneRecord = document.getElementsByClassName("tune-record");
+  for (var n = 0; n < tuneRecord.length; n++) {
+    tuneRecord[n].addEventListener("dblclick", function() {
+      stop(listNum);
+      play(this.id-1);
+    }, false);
+  };
+
+  // // リストのダブルクリックで音楽の再生
+  // document.getElementsByClassName("tune-record").addEventListener('dblclick', function(){
+  //   console.log("ok");
+  //   // play();
+  // });
+
 };
 
 // プレイヤーの処理
 // 再生
-let play = function() {
+let play = function(listNum) {
   if(!playing || pausing) {
     let bgm = list[listNum];
     getAudioBuffer(bgm, function(buffer) {
@@ -384,8 +401,7 @@ let play = function() {
       });
     });
     document.getElementById("name_artists").innerHTML = audioName[listNum];
-    console.log(listNum);
-    document.getElementById("record"+String(listNum+1)).classList.add("active")
+    document.getElementById(String(listNum+1)).classList.add("active")
   };
 };
 
@@ -397,35 +413,35 @@ let pause = function() {
 };
 
 // 停止
-let stop = function() {
+let stop = function(listNum) {
   if (soundFile != null) {
-    playing = false;
+    playing = false
     pausing = false;
     stopping = true;
     soundFile.stop(0);
     clearPlayer();
 
-    document.getElementById("record"+String(listNum+1)).classList.remove("active")
+    document.getElementById(String(listNum+1)).classList.remove("active")
   }
 };
 
 // 次の楽曲へ
 let stepForward = function() {
   if(listNum < list.length - 1) {
-    stop();
+    stop(listNum);
     clearPlayer();
     listNum++;    
-    play();
+    play(listNum);
   };
 };
 
 // 前の楽曲へ
 let stepBackward = function() {
   if(listNum > 0) {
-    stop();
+    stop(listNum);
     clearPlayer();
     listNum--;
-    play();
+    play(listNum);
   };
 };
 
@@ -452,11 +468,11 @@ window.addEventListener("DOMContentLoaded", function() {
   });
   // 音楽の再生
   document.getElementById("play").addEventListener('click', function(){
-    play();
+    play(listNum);
   });
   // 音楽の停止
   document.getElementById("stop").addEventListener('click', function(){
-    stop();
+    stop(listNum);
   });
   // 音楽の一時停止
   document.getElementById("pause").addEventListener('click', function(){
@@ -475,3 +491,14 @@ window.addEventListener("DOMContentLoaded", function() {
     stepBackward();
   });
 }, false);
+
+// // リストのダブルクリックで音楽の再生
+// document(document).on('dblclick', document.getElementsByClassName("tune-record"), function(){
+//   console.log("ok");
+// })
+
+// リストのダブルクリックで音楽の再生
+// document.getElementsByClassName("tune-record").addEventListener('dblclick', function(){
+//   console.log("ok");
+//   play();
+// });

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -284,6 +284,10 @@ function get_metadata(data, k) {
             document.getElementById("artists" + String(m)).textContent = utf8to16(comment.substr(7));
             f &= ~0x2;
           }
+          if(comment.substr(0, 6).toUpperCase() == "ALBUM=") {
+            document.getElementById("album" + String(m)).textContent = utf8to16(comment.substr(6));
+            f &= ~0x1;
+          }
           if(comment.substr(0, 12).toUpperCase() == "ALBUMARTIST=") {
             document.getElementById("album-artists" + String(m)).textContent = utf8to16(comment.substr(12));
             f &= ~0x3;
@@ -352,6 +356,8 @@ let input = function() {
     titleCell.id = 'title' + String(k+1);
     let artistsCell = row.insertCell(-1);
     artistsCell.id = 'artists' + String(k+1);
+    let albumCell = row.insertCell(-1);
+    albumCell.id = 'album' + String(k+1);
     let albumArtistsCell = row.insertCell(-1);
     albumArtistsCell.id = 'album-artists' + String(k+1);
     let lengthCell = row.insertCell(-1);
@@ -377,12 +383,6 @@ let input = function() {
       play(this.id-1);
     }, false);
   };
-
-  // // リストのダブルクリックで音楽の再生
-  // document.getElementsByClassName("tune-record").addEventListener('dblclick', function(){
-  //   console.log("ok");
-  //   // play();
-  // });
 
 };
 
@@ -491,14 +491,3 @@ window.addEventListener("DOMContentLoaded", function() {
     stepBackward();
   });
 }, false);
-
-// // リストのダブルクリックで音楽の再生
-// document(document).on('dblclick', document.getElementsByClassName("tune-record"), function(){
-//   console.log("ok");
-// })
-
-// リストのダブルクリックで音楽の再生
-// document.getElementsByClassName("tune-record").addEventListener('dblclick', function(){
-//   console.log("ok");
-//   play();
-// });

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -352,6 +352,9 @@ let input = function() {
     let row = musicTable.insertRow(-1);
     row.id = k+1;
     document.getElementById(k+1).classList.add("tune-record");
+    let IDCell = row.insertCell(-1);
+    IDCell.id = 'ID' + String(k+1);
+    IDCell.textContent = k + 1;
     let titleCell = row.insertCell(-1);
     titleCell.id = 'title' + String(k+1);
     let artistsCell = row.insertCell(-1);

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -164,14 +164,15 @@ let input = function() {
     let tr = document.createElement("tr");
     let th = document.createElement("th");
 
-    tr.setAttribute("id", "record" + String(j));
+    tr.setAttribute("id", "record");
+    tr.setAttribute("id", "data-" + String(j));
     th.setAttribute("id", "title");
 
     tr.innerHTML = "";
     th.innerHTML = audioName[j];
 
     document.getElementById("music-lists-tunes").appendChild(tr);
-    document.getElementById("record" + String(j)).appendChild(th);
+    document.getElementById("data-" + String(j)).appendChild(th);
   }
 }
 

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -324,14 +324,22 @@ let input = function() {
 
   // 取得したファイルをテーブルに表示する
   document.getElementById('music-lists-tunes').textContent = null;
-
+  let fileReader = []
   for(let j = 0; j < document.getElementById("file-upload-audio").files.length; j++) {
-    // let k = Number(document.getElementById("file-upload-audio").files.length - j)
-    file_reader = new FileReader();
-    let file = document.getElementById("file-upload-audio").files[j];
-    file_reader.readAsArrayBuffer(file);
-    file_reader.onload = function() {
-      let value = file_reader.result;
+    fileReader[j] = "fileReader" + String(j);
+  }
+  
+
+  for(let k = 0; k < document.getElementById("file-upload-audio").files.length; k++) {
+    let l = Number(document.getElementById("file-upload-audio").files.length - k)
+    console.log(l);
+
+    fileReader[k] = new FileReader();
+    let file = document.getElementById("file-upload-audio").files[k];
+    fileReader[k].readAsArrayBuffer(file);
+    console.log(fileReader[k]);
+    fileReader[k].onload = function() {
+      let value = fileReader[k].result;
       data = new Uint8Array(value);
       console.log("get_metadata start");
       get_metadata(data);
@@ -342,14 +350,14 @@ let input = function() {
     let th = document.createElement("th");
 
     tr.setAttribute("id", "record");
-    tr.setAttribute("id", "data-" + String(j));
+    tr.setAttribute("id", "data-" + String(k));
     th.setAttribute("id", "title");
 
     tr.innerHTML = "";
-    th.innerHTML = audioName[j];
+    th.innerHTML = audioName[k];
 
     document.getElementById("music-lists-tunes").appendChild(tr);
-    document.getElementById("data-" + String(j)).appendChild(th);
+    document.getElementById("data-" + String(k)).appendChild(th);
   }
 
   // file_reader = new FileReader();

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -272,20 +272,29 @@ function get_metadata(data) {
           comment += String.fromCharCode(data[i_data++]);
         }
 
-        console.log(comment)
+        // console.log(comment)
 
-        // if(comment.substr(0, 6).toUpperCase() == "TITLE=") {
-        //   document.getElementById("name1").textContent = utf8to16(comment.substr(6));
-        //   f &= ~0x1;
-        // }
-        // if(comment.substr(0, 6).toUpperCase() == "GENRE=") {
-        //   document.getElementById("name3").textContent = utf8to16(comment.substr(6));
-        //   f &= ~0x2;
-        // }
-        // if(comment.substr(0, 7).toUpperCase() == "ARTIST=") {
-        //   document.getElementById("name2").textContent = utf8to16(comment.substr(7));
-        //   f &= ~0x3;
-        // }
+        if(comment.substr(0, 6).toUpperCase() == "TITLE=") {
+          document.getElementById("title").textContent = utf8to16(comment.substr(6));
+          f &= ~0x1;
+        }
+        if(comment.substr(0, 7).toUpperCase() == "ARTIST=") {
+          document.getElementById("artists").textContent = utf8to16(comment.substr(7));
+          f &= ~0x2;
+        }
+        if(comment.substr(0, 12).toUpperCase() == "ALBUMARTIST=") {
+          document.getElementById("album-artists").textContent = utf8to16(comment.substr(12));
+          f &= ~0x3;
+        }
+        if(comment.substr(0, 7).toUpperCase() == "LENGTH=") {
+          document.getElementById("length").textContent = utf8to16(comment.substr(7));
+          f &= ~0x4;
+        }
+        if(comment.substr(0, 6).toUpperCase() == "GENRE=") {
+          document.getElementById("genre").textContent = utf8to16(comment.substr(6));
+          f &= ~0x5;
+        }
+        
       }
 
       i_data = i_skip;
@@ -323,52 +332,67 @@ let input = function() {
   document.getElementById("name_artists").innerHTML = audioName[listNum];
 
   // 取得したファイルをテーブルに表示する
-  document.getElementById('music-lists-tunes').textContent = null;
+  // document.getElementById('music-lists-tunes').textContent = null;
   let fileReader = []
   for(let j = 0; j < document.getElementById("file-upload-audio").files.length; j++) {
     fileReader[j] = "fileReader" + String(j);
   }
-  
 
+  let musicTable = document.getElementById('music-lists-tunes');
+  let row = musicTable.insertRow(-1);
+  row.id = 'record';
+  let titleCell = row.insertCell(-1);
+  titleCell.id = 'title';
+  let artistsCell = row.insertCell(-1);
+  artistsCell.id = 'artists';
+  let albumArtistsCell = row.insertCell(-1);
+  albumArtistsCell.id = 'album-artists';
+  let lengthCell = row.insertCell(-1);
+  lengthCell.id = 'length';
+  let genreCell = row.insertCell(-1);
+  genreCell.id = 'genre';
+
+  // titleCell.innerHTML = `<td id="title"></td>`;
+  // artistsCell.innerHTML = "<td></td>";
+  // albumArtistsCell.innerHTML = "<td></td>";
+  // lengthCell.innerHTML = "<td></td>";
+  // genreCell.innerHTML = "<td></td>";
+
+  console.log(titleCell.innerHTML);
+  
   for(let k = 0; k < document.getElementById("file-upload-audio").files.length; k++) {
     let l = Number(document.getElementById("file-upload-audio").files.length - k)
-    console.log(l);
+    // console.log(l);
 
     fileReader[k] = new FileReader();
     let file = document.getElementById("file-upload-audio").files[k];
     fileReader[k].readAsArrayBuffer(file);
-    console.log(fileReader[k]);
+    // console.log(fileReader[k]);
     fileReader[k].onload = function() {
       let value = fileReader[k].result;
       data = new Uint8Array(value);
-      console.log("get_metadata start");
+      // console.log("get_metadata start");
       get_metadata(data);
-      console.log("get_metadata finish");
+      // console.log("get_metadata finish");
     }
 
-    let tr = document.createElement("tr");
-    let th = document.createElement("th");
+    // let tr = document.createElement("tr");
+    // let th = document.createElement("th");
 
-    tr.setAttribute("id", "record");
-    tr.setAttribute("id", "data-" + String(k));
-    th.setAttribute("id", "title");
+    // tr.setAttribute("class", "record");
+    // tr.setAttribute("id", "data-" + String(k));
+    // th.setAttribute("id", "title");
+    // th.setAttribute("id", "artists");
+    // th.setAttribute("id", "album-artists");
+    // th.setAttribute("id", "length");
+    // th.setAttribute("id", "genre");
 
-    tr.innerHTML = "";
-    th.innerHTML = audioName[k];
+    // tr.innerHTML = "";
+    // th.innerHTML = audioName[k];
 
-    document.getElementById("music-lists-tunes").appendChild(tr);
-    document.getElementById("data-" + String(k)).appendChild(th);
+    // document.getElementById("music-lists-tunes").appendChild(tr);
+    // document.getElementById("data-" + String(k)).appendChild(th);
   }
-
-  // file_reader = new FileReader();
-  // let file = document.getElementById("file-upload-audio").files[0];
-  // file_reader.readAsArrayBuffer(file);
-  // file_reader.onload = function() {
-  //   let value = file_reader.result;
-  //   data = new Uint8Array(value);
-  //   console.log("get_metadata start");
-  //   get_metadata(data);
-  //   console.log("get_metadata finish");
 
 }
 

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -384,6 +384,8 @@ let play = function() {
       });
     });
     document.getElementById("name_artists").innerHTML = audioName[listNum];
+    console.log(listNum);
+    document.getElementById("record"+String(listNum+1)).classList.add("active")
   };
 };
 
@@ -402,6 +404,8 @@ let stop = function() {
     stopping = true;
     soundFile.stop(0);
     clearPlayer();
+
+    document.getElementById("record"+String(listNum+1)).classList.remove("active")
   }
 };
 

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -338,7 +338,7 @@ let input = function() {
   let fileReader = []
   for(let j = 0; j < document.getElementById("file-upload-audio").files.length; j++) {
     fileReader[j] = "fileReader" + String(j);
-  };
+  }
   document.getElementById('music-lists-tunes').textContent = null;
   
   for(let k = 0; k < document.getElementById("file-upload-audio").files.length; k++) {
@@ -366,9 +366,7 @@ let input = function() {
       data = new Uint8Array(value);
       get_metadata(data, k);
     };
-
-  };
-
+  }
 };
 
 // プレイヤーの処理
@@ -404,7 +402,7 @@ let stop = function() {
     stopping = true;
     soundFile.stop(0);
     clearPlayer();
-  };
+  }
 };
 
 // 次の楽曲へ

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -156,6 +156,23 @@ let input = function() {
     };
   };
   document.getElementById("name_artists").innerHTML = audioName[listNum];
+
+  // 取得したファイルをテーブルに表示する
+  document.getElementById('music-lists-tunes').textContent = null;
+
+  for(let j = 0; j < document.getElementById("file-upload-audio").files.length; j++) {
+    let tr = document.createElement("tr");
+    let th = document.createElement("th");
+
+    tr.setAttribute("id", "record" + String(j));
+    th.setAttribute("id", "title");
+
+    tr.innerHTML = "";
+    th.innerHTML = audioName[j];
+
+    document.getElementById("music-lists-tunes").appendChild(tr);
+    document.getElementById("record" + String(j)).appendChild(th);
+  }
 }
 
 // プレイヤーの処理

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -63,6 +63,8 @@
             titles
           %th#head-artists
             artists
+          %th#head-album
+            album
           %th#head-album-artists
             album artists
           %th#head-length

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -70,11 +70,5 @@
           %th#head-genres
             genre
       %tbody#music-lists-tunes
-        -# %tr#record
-        -#   %th#title
-        -#   %th#artists
-        -#   %th#album-artists
-        -#   %th#length
-        -#   %th#genre
-          
+        
   .footer-setting

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -70,5 +70,4 @@
           %th#head-genres
             genre
       %tbody#music-lists-tunes
-        
   .footer-setting

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -22,12 +22,12 @@
         = "Title"
         = "Artists"
         = "Genre"
+        %input#file-upload-audio{type: 'file', accept: "audio/*", multiple: true}
       .side-bar__content-boxes__playlists-box
         = "Playlists"
   .music-player
     .music-player__album-work
     #name_artists.music-player__name_artists
-
     .music-player__music-components
       %ul
         %li.music-player__music-components__forward
@@ -54,51 +54,26 @@
         .music-player__music-components__music-time
           %span{id: "music-time"}
             00:00:00
-
-
     .music-player__visualiser
-      %input#file-upload-audio{type: 'file', accept: "audio/*", multiple: true}
   .music-lists
     %table#music-lists-table
       %thead
         %tr
           %th
-            jackets
-          %th
             titles
           %th
             artists
           %th
+            album artists
+          %th
             length
           %th
             genre
-          %th
-            address
       %tbody#music-lists-tunes
-        %tr
-          %th
-            jackets
-          %th
-            titles
-          %th
-            artists
-          %th
-            length
-          %th
-            genre
-          %th
-            address
-        %tr
-          %th
-            jackets
-          %th
-            titles
-          %th
-            artists
-          %th
-            length
-          %th
-            genre
-          %th
-            address
+        %tr#record
+          %th#title
+          %th#artists
+          %th#albumArtists
+          %th#length
+          %th#genre
   .footer-setting

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -58,23 +58,23 @@
   .music-lists
     %table#music-lists-table
       %thead
-        %tr
-          %th
+        %tr#head-record
+          %th#head-titles
             titles
-          %th
+          %th#head-artists
             artists
-          %th
+          %th#head-album-artists
             album artists
-          %th
+          %th#head-length
             length
-          %th
+          %th#head-genres
             genre
       %tbody#music-lists-tunes
-        %tr#record
-          %th#title
-          %th#artists
-          %th#album-artists
-          %th#length
-          %th#genre
+        -# %tr#record
+        -#   %th#title
+        -#   %th#artists
+        -#   %th#album-artists
+        -#   %th#length
+        -#   %th#genre
           
   .footer-setting

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -76,4 +76,5 @@
           %th#album-artists
           %th#length
           %th#genre
+          
   .footer-setting

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -59,6 +59,8 @@
     %table#music-lists-table
       %thead
         %tr#head-record
+          %th#head-ID
+            ID
           %th#head-titles
             titles
           %th#head-artists

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -73,7 +73,7 @@
         %tr#record
           %th#title
           %th#artists
-          %th#albumArtists
+          %th#album-artists
           %th#length
           %th#genre
   .footer-setting


### PR DESCRIPTION
#Why
File APIで複数楽曲を指定した場合、どの楽曲を指定したのかわかるようにするため

#What
・flac楽曲のメタデータをリスト表示した。これにより、タイトル、アーティスト名、アルバム名、アルバムアーティスト名、ジャンルを確認することができる。
・楽曲がリストをはみ出た場合は、スクロールで見るこことができる。
・楽曲の列をダブルクリックすることで、その楽曲を再生できる。
・再生中の楽曲は、背景が変更する。