### PR TITLE
mp3のメタデータを取得する

### DIFF
--- a/app/assets/stylesheets/modules/_index.scss
+++ b/app/assets/stylesheets/modules/_index.scss
@@ -135,22 +135,22 @@ body {
         min-width: calc((100vw - 350px) * 0.03);
       }
       & tr th#head-titles {
-        min-width: calc((100vw - 350px) * 0.25);
+        min-width: calc((100vw - 350px) * 0.26);
       }
       & tr th#head-artists {
         min-width: calc((100vw - 350px) * 0.15);
       }
       & tr th#head-album {
-        min-width: calc((100vw - 350px) * 0.15);
+        min-width: calc((100vw - 350px) * 0.225);
       }
       & tr th#head-album-artists {
-        min-width: calc((100vw - 350px) * 0.25);
+        min-width: calc((100vw - 350px) * 0.15);
       }
       & tr th#head-length {
-        min-width: calc((100vw - 350px) * 0.1);
+        min-width: calc((100vw - 350px) * 0.075);
       }
       & tr th#head-genres {
-        min-width: calc((100vw - 350px) * 0.1425);
+        min-width: calc((100vw - 350px) * 0.10);
       }
     }
     & tr th {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,10 +3,10 @@
 // a relevant structure within app/javascript and only use these pack files to reference
 // that code so it'll be compiled.
 
-require("@rails/ujs").start()
-require("turbolinks").start()
-require("@rails/activestorage").start()
-require("channels")
+require("@rails/ujs").start();
+require("turbolinks").start();
+require("@rails/activestorage").start();
+require("channels");
 
 import '../packs/musicplayer';
 

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -315,25 +315,13 @@ let ID3Reader = function(){
   };
   
 	let ID3Frames = {
-    TIT2: ""
-    , TPE1: ""
-    , TALB: ""
-    , TPE2: ""
-    , TCON: ""
-		, APIC: {
-			mimeType: ""
-			, binary: null
+    TIT2: "", TPE1: "", TALB: "", TPE2: "", TCON: "", APIC: {
+      mimeType: "", binary: null
 		}
 	};
 
 	let ID3FrameID = {
-    ID3: null
-    , TIT2: null
-    , TPE1: null
-    , TALB: null
-    , TPE2: null
-    , TCON: null
-		, APIC: null
+    ID3: null, TIT2: null, TPE1: null, TALB: null, TPE2: null, TCON: null, APIC: null
   };
   
 	(function(){
@@ -603,29 +591,21 @@ let ID3Reader = function(){
 		read: function(data){
 			readID3Header(data);
 			readID3Frames(data);
-		}
-		, getTIT2: function(){
+		}, getTIT2: function(){
 			return ID3Frames.TIT2;
-		}
-		, getTPE1: function(){
+		}, getTPE1: function(){
 			return ID3Frames.TPE1;
-    }
-    , getTALB: function(){
+    }, getTALB: function(){
 			return ID3Frames.TALB;
-		}
-    , getTPE2: function(){
+		}, getTPE2: function(){
 			return ID3Frames.TPE2;
-    }
-    , getTCON: function(){
+    }, getTCON: function(){
 			return ID3Frames.TCON;
-		}
-		, getAPIC_mimeType: function(){
+		}, getAPIC_mimeType: function(){
 			return ID3Frames.APIC.mimeType;
-		}
-		, getAPIC_binary: function(){
+		}, getAPIC_binary: function(){
 			return ID3Frames.APIC.binary;
-    }
-    , getID3v2: function() {
+    }, getID3v2: function() {
       return isID3v2(data);
     }
 	};
@@ -634,13 +614,12 @@ let ID3Reader = function(){
 // Base64
 let Base64 = function(){
 
-	let _ENCODE_TABLE =  ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'
-						, 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T'
-						, 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd'
-						, 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'
-						, 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x'
-						, 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7'
-						, '8', '9', '+', '/'];
+  let _ENCODE_TABLE =  ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+    'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+    'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+    'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+  ];
 
 	let _GETA = "=";
 
@@ -777,7 +756,7 @@ let input = function() {
     fileReader[k] = new FileReader();
     let file = document.getElementById("file-upload-audio").files[k];
     fileReader[k].readAsArrayBuffer(file);
-    fileReader[k].onload = function(event) {
+    fileReader[k].onload = function() {
       let value = fileReader[k].result;
       data = new Uint8Array(value);
       get_metadata_flac(data, k);

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -11,6 +11,7 @@ let repeatFlag = false;
 let listNum = 0;
 let volumeControl = null;
 let tuneTitleList = [];
+let albumWork = [];
 
 // AudioContextの作成
 window.AudioContext = window.AudioContext || window.webkitAudioContext;
@@ -145,25 +146,23 @@ let sound = function(buffer) {
 };
 
 // flacファイルのメタデータの取得
+// 変換
 // データの配列から1バイトIntegerを取り出す
 function data_int1(data) {
   return data[i_data++];
 }
-
 // データの配列から2バイトIntegerを取り出す
 function data_int2(data) {
   let val = (data[i_data] << 8) | data[i_data + 1];
   i_data += 2
   return val;
 }
-
 // データの配列から3バイトIntegerを取り出す
 function data_int3(data) {
   let val = (data[i_data] << 16) | (data[i_data + 1] << 8) | data[i_data + 2];
   i_data += 3
   return val;
 }
-
 // データの配列から4バイトIntegerを取り出す
 // 結果のMSBが1の場合，Integerの値としては負になる
 function data_int4(data) {
@@ -171,7 +170,6 @@ function data_int4(data) {
   i_data += 4
   return val;
 }
-
 // データの配列からlittle endianの4バイトIntegerを取り出す
 // 結果のMSBが1の場合、Integerの値としては負になる
 function data_int4_le(data) {
@@ -179,7 +177,6 @@ function data_int4_le(data) {
   i_data += 4;
   return val;
 }
-
 // UTF-8 → UTF-16変換
 function utf8to16(utf8) {
   let utf16 = "";
@@ -200,10 +197,9 @@ function utf8to16(utf8) {
   return utf16;
 }
 
-// METADATA_BLOCK
 // メタデータの取得
+// METADATA_BLOCK
 function get_metadata_flac(data, k) {
-
   // flacファイルの場合
   if(data.length < 4) {
     return 0;
@@ -310,14 +306,15 @@ function get_metadata_flac(data, k) {
   return 0;
 }
 
-var ID3Reader = function(){
+let ID3Reader = function(){
 
-	var HEADER_FRAME_SIZE = 10;
+	let HEADER_FRAME_SIZE = 10;
 
-	var ID3Header = {
+	let ID3Header = {
 		VER: ""
-	};
-	var ID3Frames = {
+  };
+  
+	let ID3Frames = {
     TIT2: ""
     , TPE1: ""
     , TALB: ""
@@ -329,18 +326,7 @@ var ID3Reader = function(){
 		}
 	};
 
-	// var clearID3Header = function(){
-	// 	ID3Header.VER = "";
-	// };
-	// var clearID3Frames = function(){
-	// 	ID3Frames.TALB = "";
-	// 	ID3Frames.TIT2 = "";
-	// 	ID3Frames.TPE1 = "";
-	// 	ID3Frames.APIC.mimeType = "";
-	// 	ID3Frames.APIC.binary = "";
-	// };
-
-	var ID3FrameID = {
+	let ID3FrameID = {
     ID3: null
     , TIT2: null
     , TPE1: null
@@ -348,29 +334,29 @@ var ID3Reader = function(){
     , TPE2: null
     , TCON: null
 		, APIC: null
-	};
+  };
+  
 	(function(){
-		for (var IDName in ID3FrameID) {
-			var val = [];
-			var len = IDName.length;
-			for (var i = 0; i < len; i++) {
+		for (let IDName in ID3FrameID) {
+			let val = [];
+			let len = IDName.length;
+			for (let i = 0; i < len; i++) {
 				val[i] = IDName.charCodeAt(i);
 			}
 			ID3FrameID[IDName] = val;
 		}
 	})();
 
-	//--------------------------------------------------------------------------------
-	// iD3v2かどうかを判定
-	var isID3v2 = function(data){
-		if (data[0] === ID3FrameID["ID3"][0] && data[1] === ID3FrameID["ID3"][1] && data[2] === ID3FrameID["ID3"][2]) {
-			return true;
-		}
-		return false;
-	};
+	// // iD3v2かどうかを判定
+	// let isID3v2 = function(data){
+	// 	if (data[0] === ID3FrameID["ID3"][0] && data[1] === ID3FrameID["ID3"][1] && data[2] === ID3FrameID["ID3"][2]) {
+	// 		return true;
+	// 	}
+	// 	return false;
+	// };
 
 	// ID3のヘッダーを判定
-	var readID3Header = function(data){
+	let readID3Header = function(data){
 		if (data[3] === 0x02 && data[4] === 0x00) {
 			ID3Header.VER = "v2.2";
 		}else if (data[3] === 0x03 && data[4] === 0x00) {
@@ -380,115 +366,112 @@ var ID3Reader = function(){
 		}
 	};
 
-	// ID3のヘッダーのバージョンが2.2の判定
-	var isID3v22 = function(){
-		if (ID3Header.VER === "v2.2") {
-			return true;
-		}
-		return false;
-	};
+	// // ID3のヘッダーのバージョンが2.2の判定
+	// let isID3v22 = function(){
+	// 	if (ID3Header.VER === "v2.2") {
+	// 		return true;
+	// 	}
+	// 	return false;
+	// };
 
 	// ID3のフレームデータのサイズを計算
-	var readID3PartBodySize = function(data){
-		var size = (data[6] * Math.pow(128,3)) + (data[7] * Math.pow(128,2)) + (data[8] * Math.pow(128,1)) + (data[9] * Math.pow(128,0));
+	let readID3PartBodySize = function(data){
+		let size = (data[6] * Math.pow(128,3)) + (data[7] * Math.pow(128,2)) + (data[8] * Math.pow(128,1)) + (data[9] * Math.pow(128,0));
 		return size;
-	};
+  };
 
-	var isTIT2 = function(data, i){
+  // フレームIDの判定
+	let isTIT2 = function(data, i){
 		return isID(data, i, "TIT2");
 	};
-	var isTPE1 = function(data, i){
+	let isTPE1 = function(data, i){
 		return isID(data, i, "TPE1");
   };
-  var isTALB = function(data, i){
+  let isTALB = function(data, i){
 		return isID(data, i, "TALB");
   };
-  var isTPE2 = function(data, i){
+  let isTPE2 = function(data, i){
 		return isID(data, i, "TPE2");
   };
-  var isTCON = function(data, i){
+  let isTCON = function(data, i){
 		return isID(data, i, "TCON");
 	};
-	var isAPIC = function(data, i){
+	let isAPIC = function(data, i){
 		return isID(data, i, "APIC");
 	};
 
-	var isID = function(data, i, IDName){
+  // フレームIDの取得
+	let isID = function(data, i, IDName){
 		if (data[i] === ID3FrameID[IDName][0] && data[i+1] === ID3FrameID[IDName][1] && data[i+2] === ID3FrameID[IDName][2] && data[i+3] === ID3FrameID[IDName][3]) {
 			return true;
 		}
 		return false;
 	};
 
-	// フレームデータの文字数
-	var readFrameBodySize = function(data, i){
+	// フレームデータの文字数の取得
+	let readFrameBodySize = function(data, i){
 		return (data[i+4] << 24) | (data[i+5] << 16) | (data[i+6] << 8) | data[i+7];
 	};
 
 	// 文字エンコードの設定
-	var getStringLatin1 = function(data, beginIndex, size){
-		var latin1Uint8Array = data.subarray(beginIndex, beginIndex + size);
+	let getStringLatin1 = function(data, beginIndex, size){
+		let latin1Uint8Array = data.subarray(beginIndex, beginIndex + size);
 		return String.fromCharCode.apply(null, latin1Uint8Array);
 	};
-
-	var getStringUTF16 = function(data, beginIndex, size){
-		//LE
+	let getStringUTF16 = function(data, beginIndex, size){
+		// LE
 		if (data[beginIndex] === 0xff && data[beginIndex + 1] === 0xfe) {
 			return getStringUTF16LE(data, beginIndex + 2, size);
-		//BE
+		// BE
 		}else if (data[beginIndex] === 0xfe && data[beginIndex + 1] === 0xff) {
 			return getStringUTF16BE(data, beginIndex + 2, size);
 		}
 	};
-	var getStringUTF16LE = function(data, beginIndex, size){
+	let getStringUTF16LE = function(data, beginIndex, size){
 		return getStringUTF16Common(data, beginIndex, size, "LE");
 	};
-	var getStringUTF16BE = function(data, beginIndex, size){
+	let getStringUTF16BE = function(data, beginIndex, size){
 		return getStringUTF16Common(data, beginIndex, size, "BE");
 	};
-	var getStringUTF16Common = function(data, beginIndex, size, mode){
-		var array16BE = [];
-		var lastIndex = size + beginIndex;
-		var offset1 = 0;
-		var offset2 = 1;
+	let getStringUTF16Common = function(data, beginIndex, size, mode){
+		let array16BE = [];
+		let lastIndex = size + beginIndex;
+		let offset1 = 0;
+		let offset2 = 1;
 		if (mode === "LE") {
 			offset1 = 1;
 			offset2 = 0;
 		}
-		for (var i = beginIndex; i < lastIndex; i += 2) {
+		for (let i = beginIndex; i < lastIndex; i += 2) {
 			array16BE.push( (data[i + offset1] << 8) | data[i + offset2] );
 		}
-		//SurrogatePair OK
+		// SurrogatePair OK
 		return String.fromCharCode.apply(null, array16BE);
 	};
-
-	var getStringUTF8 = function(data, beginIndex, size){
-		var array16BE = [];
-		var lastIndex = size + beginIndex;
-		var codepoint = 0x00;
-		var highSurrogate = 0x00;
-		var lowSurrogate = 0x00;
-		var tmp = 0x00;
-		for (var i = beginIndex; i < lastIndex; ) {
-			//1byte
+	let getStringUTF8 = function(data, beginIndex, size){
+		let array16BE = [];
+		let lastIndex = size + beginIndex;
+		let codepoint = 0x00;
+		let highSurrogate = 0x00;
+		let lowSurrogate = 0x00;
+		let tmp = 0x00;
+		for (let i = beginIndex; i < lastIndex; ) {
+			// 1byte
 			if (data[i] < 0x80) {
 				codepoint = data[i];
 				array16BE.push(codepoint);
 				i++;
-
-			//2byte
+			// 2byte
 			}else if (data[i] >= 0xc2 && data[i] < 0xe0) {
 				codepoint = ((data[i] & 0x1f) << 6) | (data[i + 1] & 0x3f);
 				array16BE.push(codepoint);
 				i += 2;
-
-			//3byte
+			// 3byte
 			}else if (data[i] >= 0xe0 && data[i] < 0xf0) {
 				codepoint = ((data[i] & 0x0f) << 12) | ((data[i + 1] & 0x3f) << 6) | (data[i + 2] & 0x3f);
 				array16BE.push(codepoint);
 				i += 3;
-
-			//4byte
+			// 4byte
 			}else if (data[i] >= 0xf0 && data[i] < 0xf5) {
 				codepoint = ((data[i] & 0x07) << 18) | ((data[i + 1] & 0x3f) << 12) | ((data[i + 2] & 0x3f) << 6) | (data[i + 3] & 0x3f);
 				tmp = codepoint - 0x10000;
@@ -502,24 +485,23 @@ var ID3Reader = function(){
 		return String.fromCharCode.apply(null, array16BE);
 	};
 
-	var readText = function(data, i, IDName){
-		var size = readFrameBodySize(data, i);
-		var encodeIndex = i + HEADER_FRAME_SIZE;
-		var text = "";
+  // フレームIDのテキストデータを取得
+	let readText = function(data, i, IDName){
+		let size = readFrameBodySize(data, i);
+		let encodeIndex = i + HEADER_FRAME_SIZE;
+		let text = "";
 
-		//ISO-8859-1(Latin-1)
+    // テキストデータの文字コード変換
+		// ISO-8859-1(Latin-1)
 		if (data[encodeIndex] === 0x00) {
 			text = getStringLatin1(data, encodeIndex + 1, size - 1);
-
-		//UTF-16 with BOM
+		// UTF-16 with BOM
 		}else if (data[encodeIndex] === 0x01) {
 			text = getStringUTF16(data, encodeIndex + 1, size - 3);
-
-		//UTF-16BE without BOM
+		// UTF-16BE without BOM
 		}else if (data[encodeIndex] === 0x02) {
 			text = getStringUTF16BE(data, encodeIndex + 1, size - 1);
-
-		//UTF-8 (v2.4)
+		// UTF-8 (v2.4)
 		}else if (data[encodeIndex] === 0x03) {
 			text = getStringUTF8(data, encodeIndex + 1, size - 1);
 		}
@@ -528,68 +510,69 @@ var ID3Reader = function(){
 		return HEADER_FRAME_SIZE + size;
 	};
 
-	var isFrameHeaderFmtFlgIncludeOrgSize = function(data, beginIndex){
+	let isFrameHeaderFmtFlgIncludeOrgSize = function(data, beginIndex){
 		return ((data[beginIndex + 9] & 0x01) === 0x01);
 	};
 
-	var readFrameBodySizeV24ForAPIC = function(data, i){
+	let readFrameBodySizeV24ForAPIC = function(data, i){
 		return (data[i+4] * Math.pow(128,3)) + (data[i+5] * Math.pow(128,2)) + (data[i+6] * Math.pow(128,1)) + (data[i+7] * Math.pow(128,0));
 	};
 
-	var readMimeType = function(data, beginIndex){
-		var endIndex = beginIndex;
+	let readMimeType = function(data, beginIndex){
+		let endIndex = beginIndex;
 		while (true) {
 			if (data[endIndex] === 0x00) {
 				break;
 			}
 			endIndex++;
 		}
-		var mimeTypeUint8Array = data.subarray(beginIndex, endIndex);
+		let mimeTypeUint8Array = data.subarray(beginIndex, endIndex);
 		return String.fromCharCode.apply(null, mimeTypeUint8Array);
 	};
 
-	var getImageInUint8Array = function(data, beginIndex, size){
-		var imageUint8Array = data.subarray(beginIndex, beginIndex + size);
+	let getImageInUint8Array = function(data, beginIndex, size){
+		let imageUint8Array = data.subarray(beginIndex, beginIndex + size);
 		return imageUint8Array;
-	};
+  };
 
-	var readTIT2 = function(data, i){
+  // フレームIDのテキストデータの読み込み
+	let readTIT2 = function(data, i){
 		return readText(data, i, "TIT2");
 	};
-	var readTPE1 = function(data, i){
+	let readTPE1 = function(data, i){
 		return readText(data, i, "TPE1");
   };
-  var readTALB = function(data, i){
+  let readTALB = function(data, i){
 		return readText(data, i, "TALB");
   };
-  var readTPE2 = function(data, i){
+  let readTPE2 = function(data, i){
 		return readText(data, i, "TPE2");
   };
-  var readTCON = function(data, i){
+  let readTCON = function(data, i){
 		return readText(data, i, "TCON");
   };
-	var readAPIC = function(data, i){
-		var size = readFrameBodySize(data, i);
-		var orgSizeByte = 0;
+	let readAPIC = function(data, i){
+		let size = readFrameBodySize(data, i);
+		let orgSizeByte = 0;
 		if (ID3Header.VER === "v2.4") {
 			if (isFrameHeaderFmtFlgIncludeOrgSize(data, i)) {
 				orgSizeByte = 4;
 				size = readFrameBodySizeV24ForAPIC(data, i);
-				//やっつけv2.4対応がうまくいかず、ここで書くのを一旦終了
+				// v2.4対応がうまくいかず、ここで書くのを一旦終了
 			}
 		}
 		ID3Frames.APIC.mimeType = readMimeType(data, i + HEADER_FRAME_SIZE + 1 + orgSizeByte);
-		var len = ID3Frames.APIC.mimeType.length;
-		var imageIndex = i + HEADER_FRAME_SIZE + (1 + orgSizeByte + len + 1 + 2);
+		let len = ID3Frames.APIC.mimeType.length;
+		let imageIndex = i + HEADER_FRAME_SIZE + (1 + orgSizeByte + len + 1 + 2);
 		ID3Frames.APIC.binary = getImageInUint8Array(data, imageIndex, size - (1 + len + 1 + 2));
 		return HEADER_FRAME_SIZE + size;
 	};
 
-	// ID3のフレームを
-	var readID3Frames = function(data){
-		var len = readID3PartBodySize(data);
-		var skip = 0;
-		for (var i = 0; i < len; ) {
+	// ID3のフレームを読み込む
+	let readID3Frames = function(data){
+		let len = readID3PartBodySize(data);
+		let skip = 0;
+		for (let i = 0; i < len; ) {
       if(isTIT2(data, i)) {
 				skip = readTIT2(data, i);
 				i += skip;
@@ -615,25 +598,12 @@ var ID3Reader = function(){
 	};
 
 	return {
+    // ID3Readerの返り値としてread, getTIT2, TPE1, TALB, TPE2, TCONを返し、
+    // メソッドとして使えるように設定
 		read: function(data){
-			// if (!data){
-			// 	throw new Error("The argument of read(), 'data' is invalid.");
-			// }
-			// if (!isID3v2(data)){
-			// 	throw new Error("This MP3 file has no ID3v2 tags.");
-			// }
-
-			// clearID3Header();
-			// clearID3Frames();
-
 			readID3Header(data);
-			// if (isID3v22()){
-			// 	throw new Error("This MP3 file has ID3v2.2 tags.");
-			// }
-
 			readID3Frames(data);
 		}
-
 		, getTIT2: function(){
 			return ID3Frames.TIT2;
 		}
@@ -649,28 +619,100 @@ var ID3Reader = function(){
     , getTCON: function(){
 			return ID3Frames.TCON;
 		}
-    
-		// , getAPIC_mimeType: function(){
-		// 	return ID3Frames.APIC.mimeType;
-		// }
-		// , getAPIC_binary: function(){
-		// 	return ID3Frames.APIC.binary;
-		// }
+		, getAPIC_mimeType: function(){
+			return ID3Frames.APIC.mimeType;
+		}
+		, getAPIC_binary: function(){
+			return ID3Frames.APIC.binary;
+		}
+	};
+}();
+
+// Base64
+let Base64 = function(){
+
+	let _ENCODE_TABLE =  ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'
+						, 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T'
+						, 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd'
+						, 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'
+						, 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x'
+						, 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7'
+						, '8', '9', '+', '/'];
+
+	let _GETA = "=";
+
+	let _NUM_OF_BYTES = 3;
+
+	let encodeMain = function(data, i, outStrArray){
+		let iNum = (data[i] << 16) + (data[i+1] << 8) + (data[i+2]);
+
+		outStrArray.push( _ENCODE_TABLE[(iNum >> 18)] );
+		outStrArray.push( _ENCODE_TABLE[(iNum >> 12) & 0x3f] );
+		outStrArray.push( _ENCODE_TABLE[(iNum >> 6) & 0x3f] );
+		outStrArray.push( _ENCODE_TABLE[iNum & 0x3f] );
+  };
+  
+	let encodePlus1Geta = function(data, i, outStrArray){
+		let iNum = (data[i] << 8) + data[i+1];
+
+		outStrArray.push( _ENCODE_TABLE[(iNum >> 10)] );
+		outStrArray.push( _ENCODE_TABLE[(iNum >> 4) & 0x3f] );
+		outStrArray.push( _ENCODE_TABLE[(iNum << 2) & 0x3f] );
+		outStrArray.push( _GETA );
+  };
+  
+	let encodePlus2Geta = function(data, i, outStrArray){
+		let iNum = data[i];
+
+		outStrArray.push( _ENCODE_TABLE[(iNum >> 2)] );
+		outStrArray.push( _ENCODE_TABLE[(iNum << 4) & 0x3f] );
+		outStrArray.push( _GETA );
+		outStrArray.push( _GETA );
 	};
 
+	return {
+		encode: function(data){
+
+			if (!data){
+				return "";
+			}
+
+			let outStrArray = [];
+
+			let len = data.length;
+			let count = Math.floor(len / _NUM_OF_BYTES);
+			let mod = len % _NUM_OF_BYTES;
+
+			for (let i=0; i<count; i++) {
+				encodeMain(data, _NUM_OF_BYTES * i, outStrArray);
+			}
+
+			switch (mod) {
+				case 2:
+					encodePlus1Geta(data, _NUM_OF_BYTES * count, outStrArray);
+					break;
+				case 1:
+					encodePlus2Geta(data, _NUM_OF_BYTES * count, outStrArray);
+					break;
+			}
+
+			return outStrArray.join("");
+		}
+	};
 }();
+
+// APIC（画像の）読み込み
+function createImgElemInViewAPIC(src){
+	let img = document.getElementById("album-work");
+	img.src = src;
+  img.title = "coverImage";
+  img.height = 200; 
+}
 
 // ID3タグの読み込み
 function get_metadata_mp3(value, k){
-  var data = new Uint8Array(value);
+  let data = new Uint8Array(value);
   ID3Reader.read(data);
-
-	// try{
-	// 	ID3Reader.read(bytes);
-	// }catch(e){
-	// 	viewMsg.innerText = "ID3Reader Error : " + e.message;
-	// 	return;
-  // }
   
   m = k + 1;
   document.getElementById("title" + String(m)).textContent = ID3Reader.getTIT2();
@@ -678,21 +720,14 @@ function get_metadata_mp3(value, k){
   document.getElementById("album" + String(m)).textContent = ID3Reader.getTALB();
   document.getElementById("album-artists" + String(m)).textContent = ID3Reader.getTPE2();
   document.getElementById("genre" + String(m)).textContent = ID3Reader.getTCON();
+
+  if (ID3Reader.getAPIC_mimeType() !== "") {
+    let imgSrc = "data:" + ID3Reader.getAPIC_mimeType() + ";base64," + Base64.encode(ID3Reader.getAPIC_binary());
+    albumWork[k] = imgSrc;
+		createImgElemInViewAPIC(albumWork[0]);
+	}
   document.getElementById("name_artists").innerHTML = document.getElementById("title1").textContent;
-
-	// if (ID3Reader.getAPIC_mimeType() !== "") {
-	// 	var imgSrc = "data:" + ID3Reader.getAPIC_mimeType() + ";base64," + Base64.encode(ID3Reader.getAPIC_binary());
-	// 	createImgElemInViewAPIC(imgSrc);
-	// }
 }
-
-// // APIC（画像の）読み込み
-// function createImgElemInViewAPIC(src){
-// 	var img = document.createElement("img");
-// 	img.src = src;
-// 	img.title = "coverImage";
-// 	viewAPIC.appendChild(img);
-// }
 
 // ファイルの読み込み
 let input = function() {
@@ -742,16 +777,6 @@ let input = function() {
       data = new Uint8Array(value);
       get_metadata_flac(data, k);
       get_metadata_mp3(value, k);
-
-      // id3v2 = data.slice(0, 512);
-      // judge = id3v2[0] + id3v2[1] + id3v2[2];
-      // if(judge == 220) {
-      //   for (let i = 0; i < 513; i++) {
-      //     document.getElementById("title"+(k+1)).textContent += String.fromCharCode(id3v2[i]);
-      //     console.log(String.fromCharCode(id3v2[i]));
-      //   }
-      // }
-
       let bgm = list[k];
       getAudioBuffer(bgm, function(buffer) {
         document.getElementById('length' + String(k+1)).innerHTML = parseTime(buffer.duration);
@@ -761,7 +786,7 @@ let input = function() {
 
   // リストのダブルクリックで音楽の再生（最初のページ読み込み時にtune-recordが存在しないため、ここで作成）
   let tuneRecord = document.getElementsByClassName("tune-record");
-  for (var n = 0; n < tuneRecord.length; n++) {
+  for (let n = 0; n < tuneRecord.length; n++) {
     tuneRecord[n].addEventListener("dblclick", function() {
       stop(listNum);
       listNum = this.id - 1;
@@ -786,6 +811,7 @@ let play = function(listNum) {
     });
 
     document.getElementById("name_artists").innerHTML = document.getElementById("title"+String(listNum+1)).textContent;
+    createImgElemInViewAPIC(albumWork[listNum]);
     if(listNum !== 0) {
       document.getElementById(String(listNum)).classList.remove("active")
     }

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -347,13 +347,13 @@ let ID3Reader = function(){
 		}
 	})();
 
-	// // iD3v2かどうかを判定
-	// let isID3v2 = function(data){
-	// 	if (data[0] === ID3FrameID["ID3"][0] && data[1] === ID3FrameID["ID3"][1] && data[2] === ID3FrameID["ID3"][2]) {
-	// 		return true;
-	// 	}
-	// 	return false;
-	// };
+	// iD3v2かどうかを判定
+	let isID3v2 = function(data){
+		if (data[0] === ID3FrameID["ID3"][0] && data[1] === ID3FrameID["ID3"][1] && data[2] === ID3FrameID["ID3"][2]) {
+			return true;
+		}
+		return false;
+	};
 
 	// ID3のヘッダーを判定
 	let readID3Header = function(data){
@@ -624,7 +624,10 @@ let ID3Reader = function(){
 		}
 		, getAPIC_binary: function(){
 			return ID3Frames.APIC.binary;
-		}
+    }
+    , getID3v2: function() {
+      return isID3v2(data);
+    }
 	};
 }();
 
@@ -712,21 +715,23 @@ function createImgElemInViewAPIC(src){
 // ID3タグの読み込み
 function get_metadata_mp3(value, k){
   let data = new Uint8Array(value);
-  ID3Reader.read(data);
+  if(ID3Reader.getID3v2(data)) {
+    ID3Reader.read(data);
   
-  m = k + 1;
-  document.getElementById("title" + String(m)).textContent = ID3Reader.getTIT2();
-  document.getElementById("artists" + String(m)).textContent = ID3Reader.getTPE1();
-  document.getElementById("album" + String(m)).textContent = ID3Reader.getTALB();
-  document.getElementById("album-artists" + String(m)).textContent = ID3Reader.getTPE2();
-  document.getElementById("genre" + String(m)).textContent = ID3Reader.getTCON();
+    m = k + 1;
+    document.getElementById("title" + String(m)).textContent = ID3Reader.getTIT2();
+    document.getElementById("artists" + String(m)).textContent = ID3Reader.getTPE1();
+    document.getElementById("album" + String(m)).textContent = ID3Reader.getTALB();
+    document.getElementById("album-artists" + String(m)).textContent = ID3Reader.getTPE2();
+    document.getElementById("genre" + String(m)).textContent = ID3Reader.getTCON();
 
-  if (ID3Reader.getAPIC_mimeType() !== "") {
-    let imgSrc = "data:" + ID3Reader.getAPIC_mimeType() + ";base64," + Base64.encode(ID3Reader.getAPIC_binary());
-    albumWork[k] = imgSrc;
-		createImgElemInViewAPIC(albumWork[0]);
-	}
-  document.getElementById("name_artists").innerHTML = document.getElementById("title1").textContent;
+    if (ID3Reader.getAPIC_mimeType() !== "") {
+      let imgSrc = "data:" + ID3Reader.getAPIC_mimeType() + ";base64," + Base64.encode(ID3Reader.getAPIC_binary());
+      albumWork[k] = imgSrc;
+      createImgElemInViewAPIC(albumWork[0]);
+    }
+    document.getElementById("name_artists").innerHTML = document.getElementById("title1").textContent;
+  }
 }
 
 // ファイルの読み込み

--- a/app/javascript/packs/musicplayer.js
+++ b/app/javascript/packs/musicplayer.js
@@ -164,7 +164,7 @@ function data_int3(data) {
   return val;
 }
 
-// データの配列から4バイトInteger を取り出す
+// データの配列から4バイトIntegerを取り出す
 // 結果のMSBが1の場合，Integerの値としては負になる
 function data_int4(data) {
   let val = (data[i_data] << 24) | (data[i_data + 1] << 16) | (data[i_data + 2] << 8) | data[i_data + 3];
@@ -202,7 +202,9 @@ function utf8to16(utf8) {
 
 // METADATA_BLOCK
 // メタデータの取得
-function get_metadata(data, k) {
+function get_metadata_flac(data, k) {
+
+  // flacファイルの場合
   if(data.length < 4) {
     return 0;
   }
@@ -221,21 +223,21 @@ function get_metadata(data, k) {
     let flg_typ = data_int1(data);
     let len = data_int3(data);
     if(i_data + len > data.length) {
-      return -1;
+      return;
     }
     
     // METADATA_BLOCK_DATA
     switch(flg_typ & 0x7f) {  // BLOCK_TYPE
       case 4:  // VORBIS_COMMENT
-      // 曲タイトル，アーティスト名を取得
-      let i_skip = i_data + len;
-      if(len < 4) {
-        return false;
-      }
-      if((len = data_int4_le(data)) & 0x80000000) { // vendor_length
-        return false;
-      }
-      if(i_data + len > data.length) {
+        // 曲タイトル，アーティスト名を取得
+        let i_skip = i_data + len;
+        if(len < 4) {
+          return false;
+        }
+        if((len = data_int4_le(data)) & 0x80000000) { // vendor_length
+          return false;
+        }
+        if(i_data + len > data.length) {
           return false;
         }
         i_data += len;  // vendor_string
@@ -308,6 +310,390 @@ function get_metadata(data, k) {
   return 0;
 }
 
+var ID3Reader = function(){
+
+	var HEADER_FRAME_SIZE = 10;
+
+	var ID3Header = {
+		VER: ""
+	};
+	var ID3Frames = {
+    TIT2: ""
+    , TPE1: ""
+    , TALB: ""
+    , TPE2: ""
+    , TCON: ""
+		, APIC: {
+			mimeType: ""
+			, binary: null
+		}
+	};
+
+	// var clearID3Header = function(){
+	// 	ID3Header.VER = "";
+	// };
+	// var clearID3Frames = function(){
+	// 	ID3Frames.TALB = "";
+	// 	ID3Frames.TIT2 = "";
+	// 	ID3Frames.TPE1 = "";
+	// 	ID3Frames.APIC.mimeType = "";
+	// 	ID3Frames.APIC.binary = "";
+	// };
+
+	var ID3FrameID = {
+    ID3: null
+    , TIT2: null
+    , TPE1: null
+    , TALB: null
+    , TPE2: null
+    , TCON: null
+		, APIC: null
+	};
+	(function(){
+		for (var IDName in ID3FrameID) {
+			var val = [];
+			var len = IDName.length;
+			for (var i = 0; i < len; i++) {
+				val[i] = IDName.charCodeAt(i);
+			}
+			ID3FrameID[IDName] = val;
+		}
+	})();
+
+	//--------------------------------------------------------------------------------
+	// iD3v2かどうかを判定
+	var isID3v2 = function(data){
+		if (data[0] === ID3FrameID["ID3"][0] && data[1] === ID3FrameID["ID3"][1] && data[2] === ID3FrameID["ID3"][2]) {
+			return true;
+		}
+		return false;
+	};
+
+	// ID3のヘッダーを判定
+	var readID3Header = function(data){
+		if (data[3] === 0x02 && data[4] === 0x00) {
+			ID3Header.VER = "v2.2";
+		}else if (data[3] === 0x03 && data[4] === 0x00) {
+			ID3Header.VER = "v2.3";
+		}else if (data[3] === 0x04 && data[4] === 0x00) {
+			ID3Header.VER = "v2.4";
+		}
+	};
+
+	// ID3のヘッダーのバージョンが2.2の判定
+	var isID3v22 = function(){
+		if (ID3Header.VER === "v2.2") {
+			return true;
+		}
+		return false;
+	};
+
+	// ID3のフレームデータのサイズを計算
+	var readID3PartBodySize = function(data){
+		var size = (data[6] * Math.pow(128,3)) + (data[7] * Math.pow(128,2)) + (data[8] * Math.pow(128,1)) + (data[9] * Math.pow(128,0));
+		return size;
+	};
+
+	var isTIT2 = function(data, i){
+		return isID(data, i, "TIT2");
+	};
+	var isTPE1 = function(data, i){
+		return isID(data, i, "TPE1");
+  };
+  var isTALB = function(data, i){
+		return isID(data, i, "TALB");
+  };
+  var isTPE2 = function(data, i){
+		return isID(data, i, "TPE2");
+  };
+  var isTCON = function(data, i){
+		return isID(data, i, "TCON");
+	};
+	var isAPIC = function(data, i){
+		return isID(data, i, "APIC");
+	};
+
+	var isID = function(data, i, IDName){
+		if (data[i] === ID3FrameID[IDName][0] && data[i+1] === ID3FrameID[IDName][1] && data[i+2] === ID3FrameID[IDName][2] && data[i+3] === ID3FrameID[IDName][3]) {
+			return true;
+		}
+		return false;
+	};
+
+	// フレームデータの文字数
+	var readFrameBodySize = function(data, i){
+		return (data[i+4] << 24) | (data[i+5] << 16) | (data[i+6] << 8) | data[i+7];
+	};
+
+	// 文字エンコードの設定
+	var getStringLatin1 = function(data, beginIndex, size){
+		var latin1Uint8Array = data.subarray(beginIndex, beginIndex + size);
+		return String.fromCharCode.apply(null, latin1Uint8Array);
+	};
+
+	var getStringUTF16 = function(data, beginIndex, size){
+		//LE
+		if (data[beginIndex] === 0xff && data[beginIndex + 1] === 0xfe) {
+			return getStringUTF16LE(data, beginIndex + 2, size);
+		//BE
+		}else if (data[beginIndex] === 0xfe && data[beginIndex + 1] === 0xff) {
+			return getStringUTF16BE(data, beginIndex + 2, size);
+		}
+	};
+	var getStringUTF16LE = function(data, beginIndex, size){
+		return getStringUTF16Common(data, beginIndex, size, "LE");
+	};
+	var getStringUTF16BE = function(data, beginIndex, size){
+		return getStringUTF16Common(data, beginIndex, size, "BE");
+	};
+	var getStringUTF16Common = function(data, beginIndex, size, mode){
+		var array16BE = [];
+		var lastIndex = size + beginIndex;
+		var offset1 = 0;
+		var offset2 = 1;
+		if (mode === "LE") {
+			offset1 = 1;
+			offset2 = 0;
+		}
+		for (var i = beginIndex; i < lastIndex; i += 2) {
+			array16BE.push( (data[i + offset1] << 8) | data[i + offset2] );
+		}
+		//SurrogatePair OK
+		return String.fromCharCode.apply(null, array16BE);
+	};
+
+	var getStringUTF8 = function(data, beginIndex, size){
+		var array16BE = [];
+		var lastIndex = size + beginIndex;
+		var codepoint = 0x00;
+		var highSurrogate = 0x00;
+		var lowSurrogate = 0x00;
+		var tmp = 0x00;
+		for (var i = beginIndex; i < lastIndex; ) {
+			//1byte
+			if (data[i] < 0x80) {
+				codepoint = data[i];
+				array16BE.push(codepoint);
+				i++;
+
+			//2byte
+			}else if (data[i] >= 0xc2 && data[i] < 0xe0) {
+				codepoint = ((data[i] & 0x1f) << 6) | (data[i + 1] & 0x3f);
+				array16BE.push(codepoint);
+				i += 2;
+
+			//3byte
+			}else if (data[i] >= 0xe0 && data[i] < 0xf0) {
+				codepoint = ((data[i] & 0x0f) << 12) | ((data[i + 1] & 0x3f) << 6) | (data[i + 2] & 0x3f);
+				array16BE.push(codepoint);
+				i += 3;
+
+			//4byte
+			}else if (data[i] >= 0xf0 && data[i] < 0xf5) {
+				codepoint = ((data[i] & 0x07) << 18) | ((data[i + 1] & 0x3f) << 12) | ((data[i + 2] & 0x3f) << 6) | (data[i + 3] & 0x3f);
+				tmp = codepoint - 0x10000;
+				highSurrogate = (tmp >> 10) | 0xd800;
+				lowSurrogate = (tmp & 0x3ff) | 0xdc00;
+				array16BE.push(highSurrogate);
+				array16BE.push(lowSurrogate);
+				i += 4;
+			}
+		}
+		return String.fromCharCode.apply(null, array16BE);
+	};
+
+	var readText = function(data, i, IDName){
+		var size = readFrameBodySize(data, i);
+		var encodeIndex = i + HEADER_FRAME_SIZE;
+		var text = "";
+
+		//ISO-8859-1(Latin-1)
+		if (data[encodeIndex] === 0x00) {
+			text = getStringLatin1(data, encodeIndex + 1, size - 1);
+
+		//UTF-16 with BOM
+		}else if (data[encodeIndex] === 0x01) {
+			text = getStringUTF16(data, encodeIndex + 1, size - 3);
+
+		//UTF-16BE without BOM
+		}else if (data[encodeIndex] === 0x02) {
+			text = getStringUTF16BE(data, encodeIndex + 1, size - 1);
+
+		//UTF-8 (v2.4)
+		}else if (data[encodeIndex] === 0x03) {
+			text = getStringUTF8(data, encodeIndex + 1, size - 1);
+		}
+
+		ID3Frames[IDName] = text;
+		return HEADER_FRAME_SIZE + size;
+	};
+
+	var isFrameHeaderFmtFlgIncludeOrgSize = function(data, beginIndex){
+		return ((data[beginIndex + 9] & 0x01) === 0x01);
+	};
+
+	var readFrameBodySizeV24ForAPIC = function(data, i){
+		return (data[i+4] * Math.pow(128,3)) + (data[i+5] * Math.pow(128,2)) + (data[i+6] * Math.pow(128,1)) + (data[i+7] * Math.pow(128,0));
+	};
+
+	var readMimeType = function(data, beginIndex){
+		var endIndex = beginIndex;
+		while (true) {
+			if (data[endIndex] === 0x00) {
+				break;
+			}
+			endIndex++;
+		}
+		var mimeTypeUint8Array = data.subarray(beginIndex, endIndex);
+		return String.fromCharCode.apply(null, mimeTypeUint8Array);
+	};
+
+	var getImageInUint8Array = function(data, beginIndex, size){
+		var imageUint8Array = data.subarray(beginIndex, beginIndex + size);
+		return imageUint8Array;
+	};
+
+	var readTIT2 = function(data, i){
+		return readText(data, i, "TIT2");
+	};
+	var readTPE1 = function(data, i){
+		return readText(data, i, "TPE1");
+  };
+  var readTALB = function(data, i){
+		return readText(data, i, "TALB");
+  };
+  var readTPE2 = function(data, i){
+		return readText(data, i, "TPE2");
+  };
+  var readTCON = function(data, i){
+		return readText(data, i, "TCON");
+  };
+	var readAPIC = function(data, i){
+		var size = readFrameBodySize(data, i);
+		var orgSizeByte = 0;
+		if (ID3Header.VER === "v2.4") {
+			if (isFrameHeaderFmtFlgIncludeOrgSize(data, i)) {
+				orgSizeByte = 4;
+				size = readFrameBodySizeV24ForAPIC(data, i);
+				//やっつけv2.4対応がうまくいかず、ここで書くのを一旦終了
+			}
+		}
+		ID3Frames.APIC.mimeType = readMimeType(data, i + HEADER_FRAME_SIZE + 1 + orgSizeByte);
+		var len = ID3Frames.APIC.mimeType.length;
+		var imageIndex = i + HEADER_FRAME_SIZE + (1 + orgSizeByte + len + 1 + 2);
+		ID3Frames.APIC.binary = getImageInUint8Array(data, imageIndex, size - (1 + len + 1 + 2));
+		return HEADER_FRAME_SIZE + size;
+	};
+
+	// ID3のフレームを
+	var readID3Frames = function(data){
+		var len = readID3PartBodySize(data);
+		var skip = 0;
+		for (var i = 0; i < len; ) {
+      if(isTIT2(data, i)) {
+				skip = readTIT2(data, i);
+				i += skip;
+			}else if (isTPE1(data, i)) {
+				skip = readTPE1(data, i) - 1;
+				i += skip;
+			}else if (isTALB(data, i)) {
+				skip = readTALB(data, i);
+				i += skip;
+			}else if (isTPE2(data, i)) {
+				skip = readTPE2(data, i) - 1;
+				i += skip;
+			}else if (isTCON(data, i)) {
+				skip = readTCON(data, i) - 1;
+				i += skip;
+			}else if (isAPIC(data, i)) {
+				skip = readAPIC(data, i) - 1;
+				i += skip;
+			}else{
+				i++;
+			}
+		}
+	};
+
+	return {
+		read: function(data){
+			// if (!data){
+			// 	throw new Error("The argument of read(), 'data' is invalid.");
+			// }
+			// if (!isID3v2(data)){
+			// 	throw new Error("This MP3 file has no ID3v2 tags.");
+			// }
+
+			// clearID3Header();
+			// clearID3Frames();
+
+			readID3Header(data);
+			// if (isID3v22()){
+			// 	throw new Error("This MP3 file has ID3v2.2 tags.");
+			// }
+
+			readID3Frames(data);
+		}
+
+		, getTIT2: function(){
+			return ID3Frames.TIT2;
+		}
+		, getTPE1: function(){
+			return ID3Frames.TPE1;
+    }
+    , getTALB: function(){
+			return ID3Frames.TALB;
+		}
+    , getTPE2: function(){
+			return ID3Frames.TPE2;
+    }
+    , getTCON: function(){
+			return ID3Frames.TCON;
+		}
+    
+		// , getAPIC_mimeType: function(){
+		// 	return ID3Frames.APIC.mimeType;
+		// }
+		// , getAPIC_binary: function(){
+		// 	return ID3Frames.APIC.binary;
+		// }
+	};
+
+}();
+
+// ID3タグの読み込み
+function get_metadata_mp3(value, k){
+  var data = new Uint8Array(value);
+  ID3Reader.read(data);
+
+	// try{
+	// 	ID3Reader.read(bytes);
+	// }catch(e){
+	// 	viewMsg.innerText = "ID3Reader Error : " + e.message;
+	// 	return;
+  // }
+  
+  m = k + 1;
+  document.getElementById("title" + String(m)).textContent = ID3Reader.getTIT2();
+  document.getElementById("artists" + String(m)).textContent = ID3Reader.getTPE1();
+  document.getElementById("album" + String(m)).textContent = ID3Reader.getTALB();
+  document.getElementById("album-artists" + String(m)).textContent = ID3Reader.getTPE2();
+  document.getElementById("genre" + String(m)).textContent = ID3Reader.getTCON();
+  document.getElementById("name_artists").innerHTML = document.getElementById("title1").textContent;
+
+	// if (ID3Reader.getAPIC_mimeType() !== "") {
+	// 	var imgSrc = "data:" + ID3Reader.getAPIC_mimeType() + ";base64," + Base64.encode(ID3Reader.getAPIC_binary());
+	// 	createImgElemInViewAPIC(imgSrc);
+	// }
+}
+
+// // APIC（画像の）読み込み
+// function createImgElemInViewAPIC(src){
+// 	var img = document.createElement("img");
+// 	img.src = src;
+// 	img.title = "coverImage";
+// 	viewAPIC.appendChild(img);
+// }
+
 // ファイルの読み込み
 let input = function() {
   clearPlayer();
@@ -351,10 +737,21 @@ let input = function() {
     fileReader[k] = new FileReader();
     let file = document.getElementById("file-upload-audio").files[k];
     fileReader[k].readAsArrayBuffer(file);
-    fileReader[k].onload = function() {
+    fileReader[k].onload = function(event) {
       let value = fileReader[k].result;
       data = new Uint8Array(value);
-      get_metadata(data, k);
+      get_metadata_flac(data, k);
+      get_metadata_mp3(value, k);
+
+      // id3v2 = data.slice(0, 512);
+      // judge = id3v2[0] + id3v2[1] + id3v2[2];
+      // if(judge == 220) {
+      //   for (let i = 0; i < 513; i++) {
+      //     document.getElementById("title"+(k+1)).textContent += String.fromCharCode(id3v2[i]);
+      //     console.log(String.fromCharCode(id3v2[i]));
+      //   }
+      // }
+
       let bgm = list[k];
       getAudioBuffer(bgm, function(buffer) {
         document.getElementById('length' + String(k+1)).innerHTML = parseTime(buffer.duration);

--- a/app/views/mousike/index.html.haml
+++ b/app/views/mousike/index.html.haml
@@ -27,6 +27,7 @@
         = "Playlists"
   .music-player
     .music-player__album-work
+      %img#album-work
     #name_artists.music-player__name_artists
     .music-player__music-components
       %ul


### PR DESCRIPTION
#Why
flacファイルだけでなく、mp3の音楽ファイルを再生したときに、メタデータを表示させるため

#What
mp3のバイナリーデータにアクセスしてID3v2タグを取得し、音楽リストの各項目に
メタデータを表示した。また、アルバムワークも表示させた。